### PR TITLE
Unescape ES6 \u{xxxxxx} literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
     "description": "Escape non-ASCII symbols with Unicode character codes",
     "repository": "https://github.com/yaruson/ascii-unicode-escape",
     "license": "MIT",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "yaruson",
+    "contributors": [
+        "Nikolay Kim <ru.yaruson@gmail.com>",
+        "Michael Huang <mike@htwins.net>"
+    ],
     "engines": {
         "vscode": "^1.0.0"
     },

--- a/src/escaper.ts
+++ b/src/escaper.ts
@@ -6,7 +6,8 @@ export enum MODE {
 }
 
 const RX_NONASCII = /([^\u0000-\u007f]+)/g;
-const RX_UNICODE = /(\\u([0-9A-Fa-f]{4}))/g
+const RX_UNICODE = /(\\u([0-9A-Fa-f]{4}))/g;
+const RX_UNICODE_ES6 = /(\\u\{([0-9A-Fa-f]{1,6})\})/g;
 
 export class Escaper {
 
@@ -14,7 +15,7 @@ export class Escaper {
 
     public process(editor: vscode.TextEditor, mode: MODE) {
 
-        // Process entire document if user haven't selected a text block manually 
+        // Process entire document if user haven't selected a text block manually
         let selection = (() => {
             if (editor.selection.end.isAfter(editor.selection.start)) {
                 return editor.selection;
@@ -59,6 +60,8 @@ export class Escaper {
     public unescape(text: string): string {
         return text.replace(RX_UNICODE, (match: string, sequence: string, code: string) => {
             return String.fromCharCode(parseInt(code, 16));
+        }).replace(RX_UNICODE_ES6, (match: string, sequence: string, code: string) => {
+            return String.fromCodePoint(parseInt(code, 16));
         });
     }
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -11,6 +11,9 @@ suite("Extension Tests", () => {
     const sample = "القط";
     const sample_esc = "\\u0627\\u0644\\u0642\\u0637";
 
+    const sample_es6 = "\u{1f3c3}";
+    const sample_es6_esc = "\\u{1f3c3}";
+
     let escaper = new Escaper();
 
     // Defines a Mocha unit test
@@ -20,6 +23,10 @@ suite("Extension Tests", () => {
 
     test("Unescaping", () => {
         assert.equal(sample, escaper.unescape(sample_esc));
+    });
+
+    test("Unescaping ES6 literal", () => {
+        assert.equal(sample_es6, escaper.unescape(sample_es6_esc));
     });
 
 });


### PR DESCRIPTION
This is for the mavericks who are wild enough to employ such an
intense level of trickery in their code